### PR TITLE
Add kaolin-bubblegum for wezterm.

### DIFF
--- a/kaolin-bubblegum/wezterm/colors/kaolin-bubblegum.toml
+++ b/kaolin-bubblegum/wezterm/colors/kaolin-bubblegum.toml
@@ -1,0 +1,15 @@
+# Colorscheme based on kaolin-bubblegum theme (https://github.com/ogdenwebb/emacs-kaolin-themes)
+[colors]
+background = "#14171e"
+foreground = "#e4e4e8"
+
+cursor_bg = "#41b0f3" # blue
+# cursor_bg = "#e4e4e8" # white
+cursor_fg = "#0c0d12"
+cursor_border = "#e4e4e8"
+
+selection_bg = "#272c3a"
+selection_fg = "#e6e6e8"
+
+ansi = ["#18181b", "#e84c58", "#63e8c1", "#eed891", "#41b0f3", "#c79af4", "#6bd9db", "#e6e6e8"]
+brights = ["#879193", "#e361c3", "#31e183", "#cfb05f", "#97b8de", "#fbaed2", "#a2c5c5", "#efeff1"]

--- a/kaolin-bubblegum/wezterm/colors/kaolin-bubblegum.toml
+++ b/kaolin-bubblegum/wezterm/colors/kaolin-bubblegum.toml
@@ -3,8 +3,8 @@
 background = "#14171e"
 foreground = "#e4e4e8"
 
-cursor_bg = "#41b0f3" # blue
-# cursor_bg = "#e4e4e8" # white
+cursor_bg = "#e4e4e8" # white
+# cursor_bg = "#41b0f3" # blue
 cursor_fg = "#0c0d12"
 cursor_border = "#e4e4e8"
 

--- a/kaolin-bubblegum/wezterm/wezterm.lua
+++ b/kaolin-bubblegum/wezterm/wezterm.lua
@@ -1,0 +1,63 @@
+local wezterm = require 'wezterm';
+
+-- Kaolin Bubblegum
+local C_ACTIVE_BG = "#454459";
+local C_ACTIVE_FG = "#6bd9db";
+local C_BG = "#14171e";
+local C_HL_1 = "#41b0f3";
+local C_HL_2 = "#c79af4";
+local C_INACTIVE_FG = "#575673";
+
+wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_width)
+  if tab.is_active then
+    return {
+      {Foreground={Color=C_HL_1}},
+      {Text=" " .. tab.tab_index+1},
+      {Foreground={Color=C_HL_2}},
+      {Text=": "},
+      {Foreground={Color=C_ACTIVE_FG}},
+      {Text=tab.active_pane.title .. " "},
+      {Background={Color=C_BG}},
+      {Foreground={Color=C_HL_1}},
+      {Text="|"},
+    }
+  end
+  return {
+    {Foreground={Color=C_HL_1}},
+    {Text=" " .. tab.tab_index+1},
+    {Foreground={Color=C_HL_2}},
+    {Text=": "},
+    {Foreground={Color=C_INACTIVE_FG}},
+    {Text=tab.active_pane.title .. " "},
+    {Foreground={Color=C_HL_1}},
+    {Text="|"},
+  }
+end)
+
+return {
+  color_scheme = "kaolin-bubblegum",
+  tab_bar_at_bottom = true,
+  use_fancy_tab_bar = false,
+
+  colors = {
+    tab_bar = {
+      background = C_BG,
+      new_tab = {
+        bg_color = C_BG,
+        fg_color = C_HL_2,
+      },
+      active_tab = {
+        bg_color = C_ACTIVE_BG,
+        fg_color = C_ACTIVE_FG,
+      },
+      inactive_tab = {
+        bg_color = C_BG,
+        fg_color = C_INACTIVE_FG,
+      },
+      inactive_tab_hover = {
+        bg_color = C_BG,
+        fg_color = C_INACTIVE_FG,
+      },
+    },
+  },
+}


### PR DESCRIPTION
This adds color scheme toml and recommended retro tab bar configuration.
This part is totally optional, but provides some nice defaults if users
choose.